### PR TITLE
Chapter 5 typos

### DIFF
--- a/manuscript/05.md
+++ b/manuscript/05.md
@@ -9,7 +9,7 @@ In this chapter, I will describe these innovations.
 
 ## Standalone APIs for HttpClient
 
-Beginning with version 15, there `HttpClient` can be setup without any reference to the `HttpClientModule`. Instead, we can use `provideHttpClient` when bootstrapping our application:
+Beginning with version 15, the `HttpClient` can be set up without any reference to the `HttpClientModule`. Instead, we can use `provideHttpClient` when bootstrapping our application:
 
 ```typescript
 import { provideHttpClient, withInterceptors } from "@angular/common/http";
@@ -63,7 +63,7 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
 }
 ```
 
-The interceptor shown adds an exemplary security token to HTTP calls that are directed to specific URLs. Except that the interceptor is now a function of type `HttpInterceptorFn`, the basic functionality of this concept has not changed. As shown above, functional interceptors can be set up using `withInterceptors` when calling `provideHttpClient` .
+The interceptor shown adds an example security token to HTTP calls that are directed to specific URLs. Except that the interceptor is now a function of type `HttpInterceptorFn`, the basic functionality of this concept has not changed. As shown above, functional interceptors can be set up using `withInterceptors` when calling `provideHttpClient` .
 
 ## Interceptors and Lazy Loading
 


### PR DESCRIPTION
I'm not sure about exemplary -> example. I'm not sure what you intended that word to be, but "exemplary" doesn't seem to fit (it means "commendable" or "excellent", which didn't seem to fit.