### PR TITLE
fix: broken images in 14.md

### DIFF
--- a/manuscript/14.md
+++ b/manuscript/14.md
@@ -40,13 +40,13 @@ If you can't or don't want to run a Node.js server, you can use _ng build --prer
 
 Single page applications (SPAs) enable good runtime performance. However, the initial page load usually takes a few seconds longer than with classic web applications. This is because the browser has to load large amounts of JavaScript code in addition to the actual HTML page before it can render the page. The so-called First Meaningful Paint (FMP) only takes place after a few seconds:
 
-![Client-side rendering of a SPA](images/client-side-rendering.png)
+![Client-side rendering of a SPA](images/Client-Side-Rendering.png)
 
 While these few seconds are hardly an issue in business applications, they actually pose a problem for public web solutions such as web shops. Here it is important to keep the bounce rate low and this can be achieved, among other things, by keeping waiting times as short as possible.
 
 It is therefore common to render SPAs for such scenarios on the server side so that the server can already deliver a finished HTML page. The caller is thus quickly presented with a page. Once the JavaScript bundles have loaded, the page is also interactive. The next image illustrates this: The First Meaningful Paint (FMP) now takes place earlier. However, the site will only become interactive later (Time to Interactive, TTI).
 
-![Server-side rendering of an SPA](images/server-side-rendering.png)
+![Server-side rendering of an SPA](images/Server-Side-Rendering.png)
 
 To support solutions where the initial page load matters, Angular has offered server-side rendering (SSR) since its early days. However, the behavior of this SSR implementation has been "destructive" in the past. This means that the loaded JavaScript code re-rendered the entire page. All server-side rendered markup was replaced with client-side rendered markup. Unfortunately, this is also accompanied by a slight delay and flickering. Metrics show that this degrades startup performance.
 


### PR DESCRIPTION
I changed the markdown links.  You could close this and change the filenames to match the links if you prefer.  